### PR TITLE
Remove sleeps and more verbose printouts

### DIFF
--- a/bpy_addon_build/__init__.py
+++ b/bpy_addon_build/__init__.py
@@ -100,12 +100,10 @@ def main():
                     actions.execute_action(action, inter_dir, console)
         # Rebuild
         with console.status("[bold green]Building...") as _:
-            time.sleep(2)
             shutil.make_archive(str(build_dir / yaml_conf.build_name), "zip", inter_dir)
     else:
         # Build addon
         with console.status("[bold green]Building...") as _:
-            time.sleep(2)
             shutil.make_archive(
                 str(build_dir / yaml_conf.build_name), "zip", yaml_conf.addon_folder
             )
@@ -136,7 +134,6 @@ def main():
             shutil.rmtree(edited_path, ignore_errors=True)
             edited_path.mkdir(exist_ok=True)
             shutil.unpack_archive(built_zip, edited_path)
-            time.sleep(1)
 
 
 if __name__ == "__main__":

--- a/bpy_addon_build/__init__.py
+++ b/bpy_addon_build/__init__.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 from pathlib import Path
 from typing import List, Optional
 from rich.console import Console
@@ -52,9 +51,8 @@ def main():
         if bpy_build_yaml.exists():
             pass
         else:
-            console.print(
-                "Can't find bpy-build.yaml, maybe pass it directly?", style="bold red"
-            )
+            console.print("Can't find bpy-build.yaml, maybe pass it directly?",
+                          style="bold red")
             return
     else:
         bpy_build_yaml = Path(args["<file>"]).resolve()
@@ -134,6 +132,7 @@ def main():
             shutil.rmtree(edited_path, ignore_errors=True)
             edited_path.mkdir(exist_ok=True)
             shutil.unpack_archive(built_zip, edited_path)
+            console.print(f"Installed to {edited_path}")
 
 
 if __name__ == "__main__":

--- a/bpy_addon_build/actions.py
+++ b/bpy_addon_build/actions.py
@@ -23,7 +23,7 @@ def execute_action(action: str, inter_dir: Path, console: Console):
             console.print(output.stdout.decode("UTF-8"))
 
     elif "create_file" in action:
-        extracted_str = re.search("\((.+?)\)", action)
+        extracted_str = re.search(r"\((.+?)\)", action)
         if not extracted_str:
             console.print(
                 f"Invalid action: {action}, perhaps you forgot parenthesis?",
@@ -36,7 +36,7 @@ def execute_action(action: str, inter_dir: Path, console: Console):
             f.write("")
 
     elif "copy_file" in action:
-        extracted_str = re.search("\((.+?)\)", action)
+        extracted_str = re.search(r"\((.+?)\)", action)
         if not extracted_str:
             console.print(
                 f"Invalid action: {action}, perhaps you forgot parenthesis?",


### PR DESCRIPTION
Made this change as I felt building was slow, and I saw sleep statements which just artificially make building slower. Remember that we'd also want building to happen right before test runs too, so anything that slows this down further isn't great.

I also was finding I was only getting pep8 outputs, and none of the print statements mentioning where the installs are going to. I'm still investigate why that might be.