### PR TITLE
BpyBuild 0.4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
         "typeguard==4.1.5",
         "types-pyyaml==6.0.12.11",
         "GitPython==3.1.43",
-        "tomli==2.0.1"
+        "tomli==2.0.1",
+        "packaging==24.1"
       ]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,8 @@ repos:
         "rich==13.7.0",
         "typeguard==4.1.5",
         "types-pyyaml==6.0.12.11",
-        "GitPython==3.1.43"
+        "GitPython==3.1.43",
+        "tomli==2.0.1"
       ]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/bpy_addon_build/__init__.py
+++ b/bpy_addon_build/__init__.py
@@ -27,7 +27,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Disclaimer: This is not a product from VLK Architects, nor is this endorsed by VLK Architects
+# Disclaimer: This is not a product from VLK Architects or VLK Experience Design,
+# nor is this endorsed by VLK Architects or VLK Experience Design
 
 from __future__ import annotations
 

--- a/bpy_addon_build/__init__.py
+++ b/bpy_addon_build/__init__.py
@@ -27,6 +27,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Disclaimer: This is not a product from VLK Architects, nor is this endorsed by VLK Architects
+
 from __future__ import annotations
 
 from decimal import getcontext

--- a/bpy_addon_build/__init__.py
+++ b/bpy_addon_build/__init__.py
@@ -66,11 +66,11 @@ def main() -> None:
     with open(cli.path, "r") as f:
         data: ConfigDict = yaml.safe_load(f)
         config: Config = build_config(data)
-        api: Api = Api(config, cli.path, cli.debug_mode)
+        api: Api = Api(config, cli, cli.debug_mode)
         context = BuildContext(cli.path, config, cli, api)
 
-    if cli.debug_mode:
-        console.print(context)
+        if cli.debug_mode:
+            console.print(context)
     if not cli.path.parent.joinpath(config.addon_folder).exists():
         print("Addon folder does not exist!")
         return

--- a/bpy_addon_build/api/__init__.py
+++ b/bpy_addon_build/api/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Optional
 
+from bpy_addon_build.args import Args
 from bpy_addon_build.config import Config
 
 
@@ -46,15 +47,16 @@ class Api:
         Action name to module
     """
 
-    def __init__(self, conf: Config, config_path: Path, debug_mode: bool) -> None:
+    def __init__(self, conf: Config, cli: Args, debug_mode: bool) -> None:
         if conf.build_actions is not None:
             self.build_actions = conf.build_actions
             self.action_mods: dict[str, ModuleType] = {}
+            self.actions_to_execute: list[str] = cli.actions + conf.additional_actions
 
             for action in self.build_actions:
                 if self.build_actions[action].script is None:
                     continue
-                mod = self.add_modules(config_path, action, debug_mode)
+                mod = self.add_modules(cli.path, action, debug_mode)
                 if mod is None:
                     continue
                 self.action_mods[action] = mod

--- a/bpy_addon_build/build_context/build.py
+++ b/bpy_addon_build/build_context/build.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from bpy_addon_build.build_context import hooks
 from bpy_addon_build.build_context.core import BuildContext
-from lib_bpybuild_ext import build_ext
 
 
 def combine_with_build(ctx: BuildContext, path: Path) -> Path:
@@ -70,15 +69,6 @@ def build(ctx: BuildContext) -> Path:
 
     hooks.run_main_hooks(ctx, STAGE_ONE, Path(ctx.config.build_name))
 
-    if ctx.config.build_extension and ctx.config.extension_settings is not None:
-        return build_ext(
-            STAGE_ONE,
-            BUILD_DIR,
-            ctx.config.extension_settings.build_name
-            if ctx.config.extension_settings.build_name is not None
-            else ctx.config.build_name,
-        )
-    else:
-        combined_str = str(combine_with_build(ctx, BUILD_DIR))
-        shutil.make_archive(combined_str, "zip", STAGE_ONE)
-        return Path(combined_str + ".zip")
+    combined_str = str(combine_with_build(ctx, BUILD_DIR))
+    _ = shutil.make_archive(combined_str, "zip", STAGE_ONE)
+    return Path(combined_str + ".zip")

--- a/bpy_addon_build/build_context/build.py
+++ b/bpy_addon_build/build_context/build.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from bpy_addon_build.build_context import hooks
 from bpy_addon_build.build_context.core import BuildContext
+from lib_bpybuild_ext import build_ext
 
 
 def combine_with_build(ctx: BuildContext, path: Path) -> Path:
@@ -69,6 +70,15 @@ def build(ctx: BuildContext) -> Path:
 
     hooks.run_main_hooks(ctx, STAGE_ONE, Path(ctx.config.build_name))
 
-    combined_str = str(combine_with_build(ctx, BUILD_DIR))
-    shutil.make_archive(combined_str, "zip", STAGE_ONE)
-    return Path(combined_str + ".zip")
+    if ctx.config.build_extension and ctx.config.extension_settings is not None:
+        return build_ext(
+            STAGE_ONE,
+            BUILD_DIR,
+            ctx.config.extension_settings.build_name
+            if ctx.config.extension_settings.build_name is not None
+            else ctx.config.build_name,
+        )
+    else:
+        combined_str = str(combine_with_build(ctx, BUILD_DIR))
+        shutil.make_archive(combined_str, "zip", STAGE_ONE)
+        return Path(combined_str + ".zip")

--- a/bpy_addon_build/build_context/core.py
+++ b/bpy_addon_build/build_context/core.py
@@ -10,9 +10,9 @@ from bpy_addon_build.args import Args
 from bpy_addon_build.config import Config
 
 INSTALL_PATHS: list[str] = [
-    "~/AppData/Roaming/Blender Foundation/Blender/{0}/scripts/addons",
-    "~/Library/Application Support/Blender/{0}/scripts/addons",
-    "~/.config/blender/{0}/scripts/addons",
+    "~/AppData/Roaming/Blender Foundation/Blender/",
+    "~/Library/Application Support/Blender/",
+    "~/.config/blender/",
 ]
 
 # Must be ignored because Mypy likes

--- a/bpy_addon_build/build_context/hook_definitions.py
+++ b/bpy_addon_build/build_context/hook_definitions.py
@@ -88,10 +88,10 @@ def check_action(ctx: BuildContext, action: str, console: Console) -> bool:
         True if all checks pass,
         False otherwise
     """
-    if ctx.config.build_actions is None and len(ctx.cli.actions):
+    if ctx.config.build_actions is None and len(ctx.api.actions_to_execute):
         print("Actions must be defined to use them!")
         return False
-    if action not in ctx.cli.actions:
+    if action not in ctx.api.actions_to_execute:
         return False
     if action not in ctx.api.action_mods:
         if ctx.cli.debug_mode:

--- a/bpy_addon_build/build_context/hooks.py
+++ b/bpy_addon_build/build_context/hooks.py
@@ -12,34 +12,34 @@ from bpy_addon_build.build_context.hook_definitions import (
 
 
 def run_prebuild_hooks(ctx: BuildContext) -> None:
-    if len(ctx.cli.actions):
+    if len(ctx.api.actions_to_execute):
         cwd = Path(ctx.config_path.parent, ctx.config.addon_folder).expanduser()
-        for k in ctx.cli.actions:
+        for k in ctx.api.actions_to_execute:
             build_action_prebuild(ctx, k, console, BabContext(cwd))
 
 
 def run_main_hooks(ctx: BuildContext, stage_one: Path, addon_folder: Path) -> None:
-    if len(ctx.cli.actions):
+    if len(ctx.api.actions_to_execute):
         cwd = stage_one.joinpath(addon_folder.name).expanduser()
-        for k in ctx.cli.actions:
+        for k in ctx.api.actions_to_execute:
             build_action_main(ctx, k, console, BabContext(cwd))
 
 
 def run_preinstall_hooks(ctx: BuildContext, zip_path: Path) -> None:
-    if len(ctx.cli.actions):
+    if len(ctx.api.actions_to_execute):
         cwd = zip_path.expanduser().parent
-        for k in ctx.cli.actions:
+        for k in ctx.api.actions_to_execute:
             build_action_preinstall(ctx, k, console, BabContext(cwd))
 
 
 def run_postinstall_hooks(ctx: BuildContext, v_path: Path) -> None:
-    if len(ctx.cli.actions):
-        for k in ctx.cli.actions:
+    if len(ctx.api.actions_to_execute):
+        for k in ctx.api.actions_to_execute:
             build_action_postinstall(ctx, k, console, BabContext(v_path))
 
 
 def run_cleanup_hooks(ctx: BuildContext) -> None:
-    if len(ctx.cli.actions):
+    if len(ctx.api.actions_to_execute):
         cwd = Path(ctx.config_path.parent, ctx.config.addon_folder).expanduser()
-        for k in ctx.cli.actions:
+        for k in ctx.api.actions_to_execute:
             build_action_cleanup(ctx, k, console, BabContext(cwd))

--- a/bpy_addon_build/build_context/install.py
+++ b/bpy_addon_build/build_context/install.py
@@ -31,11 +31,15 @@ def get_paths(
                     path = Path(p, str(format(v, ".1f"))).expanduser()
                     if not path.exists():
                         continue
-            if is_extension:
+            if is_extension and v >= +Decimal(4.2):
                 path = Path(path, "extensions/user_default")
+                paths.append(path)
+            elif is_extension and v < +Decimal(4.2):
+                # Don't install in earlier versions
+                pass
             else:
                 path = Path(path, "scripts/addons")
-            paths.append(path)
+                paths.append(path)
     return paths
 
 

--- a/bpy_addon_build/build_context/install.py
+++ b/bpy_addon_build/build_context/install.py
@@ -9,10 +9,10 @@ from bpy_addon_build.build_context import hooks
 from bpy_addon_build.build_context.core import INSTALL_PATHS, BuildContext, console
 
 
-def get_paths(versions: Union[list[float], list[Decimal]]) -> list[Path]:
-    """Given a list of versions, return paths
-    that exist to the corresponding addon folders
-    on the system.
+def get_paths(
+    versions: Union[list[float], list[Decimal]], is_extension: bool = False
+) -> list[Path]:
+    """Given a list of versions, return paths that exist to the corresponding addon folders on the system.
 
     Returns:
         - List[Path]: List of paths that exist
@@ -20,17 +20,21 @@ def get_paths(versions: Union[list[float], list[Decimal]]) -> list[Path]:
     paths: list[Path] = []
     for v in versions:
         for p in INSTALL_PATHS:
-            path = Path(p.format(str(v))).expanduser()
+            path = Path(p, str(v)).expanduser()
 
             # TODO: Figure out a way to clean up this logic
             if not path.exists():
                 # For cases like 2.8, 2.9, etc, check with this method
-                path = Path(p.format(str(format(v, ".2f")))).expanduser()
+                path = Path(p, str(format(v, ".2f"))).expanduser()
                 if not path.exists():
                     # For versions made by ranges
-                    path = Path(p.format(str(format(v, ".1f")))).expanduser()
+                    path = Path(p, str(format(v, ".1f"))).expanduser()
                     if not path.exists():
                         continue
+            if is_extension:
+                path = Path(path, "extensions/user_default")
+            else:
+                path = Path(path, "scripts/addons")
             paths.append(path)
     return paths
 
@@ -55,7 +59,7 @@ def install(ctx: BuildContext, build_path: Path) -> None:
     # For some weird reason, Mypy is complaining about
     # passing some argument of type object, but the versions
     # argument is correct...
-    for path in get_paths(versions):  # type: ignore[arg-type]
+    for path in get_paths(versions, ctx.config.build_extension):  # type: ignore[arg-type]
         addon_path = path.joinpath(Path(ctx.config.build_name))
 
         # Remove previous install

--- a/bpy_addon_build/built_in_actions/extension.py
+++ b/bpy_addon_build/built_in_actions/extension.py
@@ -1,0 +1,42 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, Mahid Sheikh
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Disclaimer: This is not a product from VLK Architects or VLK Experience Design,
+# nor is this endorsed by VLK Architects or VLK Experience Design
+
+from pathlib import Path
+
+from bpy_addon_build.api import BabContext
+from lib_bpybuild_ext import BLENDER_MANIFEST, get_manifest_data, verify
+
+
+def main(ctx: BabContext) -> None:
+    manifest_path = Path(ctx.current_path, BLENDER_MANIFEST)
+    manifest_data = get_manifest_data(manifest_path)
+    verify.verify_manifest(manifest_data, manifest_path)

--- a/bpy_addon_build/config.py
+++ b/bpy_addon_build/config.py
@@ -215,6 +215,9 @@ def build_config(data: ConfigDict) -> Config:
                 if REMOVE_BL_INFO in extension_settings_data and BUILD_LEGACY not in extension_settings_data:
                     print_error("Cannot set remove_bl_info if legacy builds are not performed!", console)
                     exit_fail()
+                if BUILD_NAME in extension_settings_data and not check_string(extension_settings_data[BUILD_NAME]):
+                    print_error("extension_settings::build_name uses unsupported characters!", console)
+                    exit_fail()
                 parsed_extension_settings = ExtensionSettings(
                         blender_binary=extension_settings_data[BLENDER_BINARY],
                         build_legacy=extension_settings_data[BUILD_LEGACY] if BUILD_LEGACY in extension_settings_data else False,

--- a/bpy_addon_build/config.py
+++ b/bpy_addon_build/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import traceback
 from decimal import Decimal, getcontext
 from typing import Dict, List, Literal, Optional, TypedDict
@@ -9,7 +8,7 @@ from attrs import frozen
 from rich.console import Console
 from typing_extensions import NotRequired, Union
 
-from .util import EXIT_FAIL, check_string, print_error
+from .util import exit_fail, check_string, print_error
 
 # Base settings
 ADDON_FOLDER: Literal["addon_folder"] = "addon_folder"
@@ -179,7 +178,7 @@ def build_config(data: ConfigDict) -> Config:
     try:
         if ADDON_FOLDER not in data:
             print_error("addon_folder not defined!", console)
-            sys.exit(EXIT_FAIL)
+            exit_fail()
 
         # Disallow '.' as a folder option
         # as it's been found to cause issues
@@ -192,30 +191,30 @@ def build_config(data: ConfigDict) -> Config:
         # As such, this is simply not allowed.
         elif data[ADDON_FOLDER] == ".":
             print_error("Addon must be in a subfolder!", console)
-            sys.exit(EXIT_FAIL)
+            exit_fail()
         elif not check_string(data[ADDON_FOLDER]):
             print_error("addon_folder uses unsupported characters!", console)
-            sys.exit(EXIT_FAIL)
+            exit_fail()
 
         if BUILD_NAME not in data:
             print_error("build_name must be defined!", console)
-            sys.exit(EXIT_FAIL)
+            exit_fail()
         elif not check_string(data[BUILD_NAME]):
             print_error("build_name uses unsupported characters!", console)
-            sys.exit(EXIT_FAIL)
+            exit_fail()
 
         if BUILD_EXTENSION in data and data[BUILD_EXTENSION]:
             if EXTENSION_SETTINGS not in data:
                 print_error("Must provide extension_settings if building an extension!", console)
-                sys.exit(EXIT_FAIL)
+                exit_fail()
             else:
                 extension_settings_data = data[EXTENSION_SETTINGS]
                 if BLENDER_BINARY not in extension_settings_data:
                     print_error("Must provide path to a Blender 4.2+ binary to build an extension!", console)
-                    sys.exit(EXIT_FAIL)
+                    exit_fail()
                 if REMOVE_BL_INFO in extension_settings_data and BUILD_LEGACY not in extension_settings_data:
                     print_error("Cannot set remove_bl_info if legacy builds are not performed!", console)
-                    sys.exit(EXIT_FAIL)
+                    exit_fail()
                 parsed_extension_settings = ExtensionSettings(
                         blender_binary=extension_settings_data[BLENDER_BINARY],
                         build_legacy=extension_settings_data[BUILD_LEGACY] if BUILD_LEGACY in extension_settings_data else False,
@@ -234,13 +233,13 @@ def build_config(data: ConfigDict) -> Config:
                     install_versions += version_shorthand_expand(ver)
                 else:
                     print_error(f"{ver} isn't a valid floating point value", console)
-                    sys.exit(EXIT_FAIL)
+                    exit_fail()
 
         if BUILD_ACTIONS in data:
             for act in data[BUILD_ACTIONS]:
                 if not check_string(act):
                     print_error(f"{act} uses unsupported characters!", console)
-                    sys.exit(EXIT_FAIL)
+                    exit_fail()
                 action_data = data[BUILD_ACTIONS][act]
                 if action_data is not None:
                     # We need to make sure the script name
@@ -255,7 +254,7 @@ def build_config(data: ConfigDict) -> Config:
                             f"Script defined for {act} uses unsupported characters in file name!",
                             console,
                         )
-                        sys.exit(EXIT_FAIL)
+                        exit_fail()
 
                     # Add the action to parsed_build_acts to
                     # use later in Config construction
@@ -270,13 +269,13 @@ def build_config(data: ConfigDict) -> Config:
                 # If an action has nothing defined, what's the
                 # point of said action?
                 print_error(f"{act} must have something defined!", console)
-                sys.exit(EXIT_FAIL)
+                exit_fail()
 
     except Exception as e:
         console.print(e)
         console.print(traceback.format_exc())
         console.print(data)
-        sys.exit(EXIT_FAIL)
+        exit_fail()
 
     return Config(
         addon_folder=data["addon_folder"],

--- a/bpy_addon_build/config.py
+++ b/bpy_addon_build/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import traceback
 from decimal import Decimal, getcontext
+from pathlib import Path
 from typing import Dict, List, Literal, Optional, TypedDict
 
 from attrs import frozen
@@ -81,6 +82,12 @@ class BuildAction:
 
     script: Optional[str] = None
     ignore_filters: Optional[List[str]] = None
+
+
+BUILT_IN_ACTIONS_FOLDER = Path(__file__).parent.joinpath("built_in_actions")
+BUILT_IN_ACTS = {
+    "extension": BuildAction(str(BUILT_IN_ACTIONS_FOLDER.joinpath("extension.py")))
+}
 
 
 # Must be ignored to pass Mypy as this has
@@ -250,6 +257,7 @@ def build_config(data: ConfigDict) -> Config:
                     and extension_settings_data[BUILD_LEGACY]
                     else False,
                 )
+                parsed_build_acts["extension"] = BUILT_IN_ACTS["extension"]
 
         if INSTALL_VERSIONS in data:
             for ver in data[INSTALL_VERSIONS]:

--- a/bpy_addon_build/config.py
+++ b/bpy_addon_build/config.py
@@ -213,7 +213,7 @@ def build_config(data: ConfigDict) -> Config:
                     print_error("Must provide path to a Blender 4.2+ binary to build an extension!", console)
                     exit_fail()
                 if REMOVE_BL_INFO in extension_settings_data and BUILD_LEGACY not in extension_settings_data:
-                    print_error("Cannot set remove_bl_info if legacy builds are not performed!", console)
+                    print_error("Cannot set extension_settings::remove_bl_info if legacy builds are not performed!", console)
                     exit_fail()
                 if BUILD_NAME in extension_settings_data and not check_string(extension_settings_data[BUILD_NAME]):
                     print_error("extension_settings::build_name uses unsupported characters!", console)

--- a/bpy_addon_build/util.py
+++ b/bpy_addon_build/util.py
@@ -1,4 +1,5 @@
 import string
+import sys
 
 from rich.console import Console
 
@@ -16,6 +17,9 @@ EXIT_FAIL: int = 1
 # TODO: Handle backslash in the importing of scripts itself
 ALLOWED_CHARS = set(string.ascii_letters + string.digits + string.whitespace + "-_/")
 
+def exit_fail() -> None:
+    """Exit the program. This is equal to sys.exit(EXIT_FAIL)"""
+    sys.exit(EXIT_FAIL)
 
 def check_string(string: str) -> bool:
     """Check if string has proper input.

--- a/bpy_addon_build/util.py
+++ b/bpy_addon_build/util.py
@@ -17,9 +17,11 @@ EXIT_FAIL: int = 1
 # TODO: Handle backslash in the importing of scripts itself
 ALLOWED_CHARS = set(string.ascii_letters + string.digits + string.whitespace + "-_/")
 
+
 def exit_fail() -> None:
     """Exit the program. This is equal to sys.exit(EXIT_FAIL)"""
     sys.exit(EXIT_FAIL)
+
 
 def check_string(string: str) -> bool:
     """Check if string has proper input.

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 default: format mypy
   poetry build
   pipx uninstall bpy-addon-build
-  pipx install $(ls -t dist/bpy_addon_build-0.3.*-py3-none-any.whl | head -1)
+  pipx install $(ls -t dist/bpy_addon_build-*-py3-none-any.whl | head -1)
 
 mypy:
   poetry run mypy --pretty bpy_addon_build

--- a/lib_bpybuild_ext/README.md
+++ b/lib_bpybuild_ext/README.md
@@ -2,4 +2,4 @@
 
 LibBpyBuildExt is a BSD 3-Clause reimplementation of the Blender Extension builder, with the goal of creating an implementation of the Blender Extension builder under a more permissive license, and as a library. This exists because the Blender Extension builder, while open source, is under the GPL. Since BpyBuild is under the BSD 3-Clause license, a permissive reimplementation is necessary.
 
-The goal is to have 100% parity with the Blender Extension builder. Part of this includes documenting the extension building process under the hood, to fill in existing gaps in the Blender documentation.
+Although the goal initially was to have 100% feature parity with the Blender Extension builder, we've since decided that full feature parity [is impractical](https://github.com/Moo-Ack-Productions/bpy-build/issues/18#issuecomment-2186680088). Thus, LibBpyBuildExt will only implement what the Blender Manual for extensions mentions.

--- a/lib_bpybuild_ext/README.md
+++ b/lib_bpybuild_ext/README.md
@@ -1,0 +1,5 @@
+# LibBpyBuildExt
+
+LibBpyBuildExt is a BSD 3-Clause reimplementation of the Blender Extension builder, with the goal of creating an implementation of the Blender Extension builder under a more permissive license, and as a library. This exists because the Blender Extension builder, while open source, is under the GPL. Since BpyBuild is under the BSD 3-Clause license, a permissive reimplementation is necessary.
+
+The goal is to have 100% parity with the Blender Extension builder. Part of this includes documenting the extension building process under the hood, to fill in existing gaps in the Blender documentation.

--- a/lib_bpybuild_ext/__init__.py
+++ b/lib_bpybuild_ext/__init__.py
@@ -134,7 +134,7 @@ def get_manifest_data(manifest_path: Path) -> manifest.ManifestData:
 
 def build_ext(
     ext_path: Path, output_path: Path, build_name: str, validate_manifest: bool = True
-) -> None:
+) -> Path:
     """Build an extension
 
     This takes the extension located at ext_path and builds
@@ -151,6 +151,9 @@ def build_ext(
 
     :param validate_manifest: Whether to validate the manifest or not; defaults to True
     :type validate_manifest: bool optional
+
+    :return: Path to built extension
+    :rtype: Path
 
     :raises NotADirectoryError: If ext_path or output_path is not a directory
     :raises FileExistsError: If ext_path and output_path are the same
@@ -180,5 +183,6 @@ def build_ext(
     if validate_manifest:
         verify.verify_manifest(manifest_data, manifest_path)
 
-    output_archive_path = str(Path(output_path, build_name + ".zip"))
+    output_archive_path = str(Path(output_path, build_name))
     _ = shutil.make_archive(output_archive_path, "zip", ext_path)
+    return Path(output_archive_path + ".zip")

--- a/lib_bpybuild_ext/__init__.py
+++ b/lib_bpybuild_ext/__init__.py
@@ -1,0 +1,137 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, Mahid Sheikh
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Disclaimer: This is not a product from VLK Architects or VLK Experience Design,
+# nor is this endorsed by VLK Architects or VLK Experience Design
+
+# This is a reimplementation of the Blender Extension builder due to licensing
+# restrictions. BpyBuild is under the BSD 3-Clause license, whereas the Blender
+# Extension builder is under the GPL-2.0-or-later license. Thus, we simply can't
+# use the Blender implementation in BpyBuild.
+#
+# Some might call us evil for this, but it's simply impractical for us to relicense
+# a BSD 3-Clause licensed program under the GPL, especially one with an API.
+#
+# This reimplementation will be independent from the rest of BpyBuild so that developers
+# can create tools around Blender Extensions with a library that is under a more permissive
+# license.
+#
+# Unlike the rest of BpyBuild, where exceptions aren't really used, this library will
+# use exceptions since that's common in the Python world. All functions that can raise an
+# exception explicitly will say what they can raise in their documentation.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import tomli
+
+from . import manifest
+
+BLENDER_MANIFEST = "blender_manifest.toml"
+
+
+def get_manifest_data(manifest_path: Path) -> manifest.ManifestData:
+    """Read blender_manifest.toml and parse it into an object representing the manifest data.
+
+    :param manifest_path: The path to blender_manifest.toml
+    :type manifest_path: Path
+
+    :return: Python object representing the manifest data
+    :rtype: ManifestData optional
+
+    :raises FileNotFoundError: If manifest_path is not found
+    :raises tomli.TOMLDecodeError: If blender_manifest.toml is invalid
+    :raises TypeError: If a manifest value in blender_manifest.toml is not the correct type or value
+    """
+
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"{manifest_path} does not exist!")
+
+    with open(manifest_path, "rb") as mf:
+        raw_manifest_data: manifest.ManifestTypedDict = cast(
+            manifest.ManifestTypedDict, tomli.load(mf)
+        )
+
+    manifest_data = manifest.ManifestData()
+
+    # Iterate over all of the items in the manifest.
+    #
+    # In order to simply this entire loop, we take
+    # advantage of hasattr, getattr, and setattr, which
+    # allow us to dynamically check, get, and set an attr
+    # on manifest_data based on the string keys in raw_manifest_data.
+    for key, val in raw_manifest_data.items():
+        if hasattr(manifest_data, key):
+            if not isinstance(val, getattr(manifest_data, key)):  # type: ignore[misc]
+                # TODO: Implement a way to tell the user what type it should be
+                raise TypeError(
+                    f"{key} is not the correct type! See the Blender docs for more info"
+                )
+            setattr(manifest_data, key, val)  # type: ignore[misc]
+    return manifest_data
+
+
+def build_ext(ext_path: Path, output_path: Path) -> None:
+    """Build an extension
+
+    This takes the extension located at ext_path and builds
+    the extension in output_path.
+
+    :param ext_path: The folder where the extension is stored
+    :type ext_path: Path
+
+    :param output_path: The folder where the final build should be outputted
+    :type output_path: Path
+
+    :raises NotADirectoryError: If ext_path or output_path is not a directory
+    :raises FileExistsError: If ext_path and output_path are the same
+    :raises FileNotFoundError: If ext_path, output_path, or  ext_path/blender_manifest.toml are not found
+    """
+
+    if not ext_path.exists():
+        raise FileNotFoundError("Extension path doesn't exist!")
+
+    if not ext_path.is_dir():
+        raise NotADirectoryError(f"Extension path must a directory, got {ext_path}")
+
+    if not output_path.exists():
+        raise FileNotFoundError("Output path doesn't exist!")
+
+    if not output_path.is_dir():
+        raise NotADirectoryError(f"Output path must be a directory, got {output_path}")
+
+    if ext_path == output_path:
+        raise FileExistsError("Extension path and output path are the same!")
+
+    manifest_path = Path(ext_path, BLENDER_MANIFEST)
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Can not find {manifest_path}")
+    _manifest_data = get_manifest_data(manifest_path)

--- a/lib_bpybuild_ext/__init__.py
+++ b/lib_bpybuild_ext/__init__.py
@@ -55,13 +55,12 @@
 from __future__ import annotations
 
 import re
-import shutil
 from pathlib import Path
 from typing import cast
 
 import tomli
 
-from . import manifest, verify
+from . import manifest
 
 BLENDER_MANIFEST = "blender_manifest.toml"
 
@@ -130,59 +129,3 @@ def get_manifest_data(manifest_path: Path) -> manifest.ManifestData:
                 )
             setattr(manifest_data, key, val)  # type: ignore[misc]
     return manifest_data
-
-
-def build_ext(
-    ext_path: Path, output_path: Path, build_name: str, validate_manifest: bool = True
-) -> Path:
-    """Build an extension
-
-    This takes the extension located at ext_path and builds
-    the extension in output_path.
-
-    :param ext_path: The folder where the extension is stored
-    :type ext_path: Path
-
-    :param output_path: The folder where the final build should be outputted
-    :type output_path: Path
-
-    :param build_name: The name of the built extension WITHOUT .zip
-    :type build_name: str
-
-    :param validate_manifest: Whether to validate the manifest or not; defaults to True
-    :type validate_manifest: bool optional
-
-    :return: Path to built extension
-    :rtype: Path
-
-    :raises NotADirectoryError: If ext_path or output_path is not a directory
-    :raises FileExistsError: If ext_path and output_path are the same
-    :raises FileNotFoundError: If ext_path, output_path, or  ext_path/blender_manifest.toml are not found
-    """
-
-    if not ext_path.exists():
-        raise FileNotFoundError("Extension path doesn't exist!")
-
-    if not ext_path.is_dir():
-        raise NotADirectoryError(f"Extension path must a directory, got {ext_path}")
-
-    if not output_path.exists():
-        raise FileNotFoundError("Output path doesn't exist!")
-
-    if not output_path.is_dir():
-        raise NotADirectoryError(f"Output path must be a directory, got {output_path}")
-
-    if ext_path == output_path:
-        raise FileExistsError("Extension path and output path are the same!")
-
-    manifest_path = Path(ext_path, BLENDER_MANIFEST)
-    if not manifest_path.exists():
-        raise FileNotFoundError(f"Can not find {manifest_path}")
-    manifest_data = get_manifest_data(manifest_path)
-
-    if validate_manifest:
-        verify.verify_manifest(manifest_data, manifest_path)
-
-    output_archive_path = str(Path(output_path, build_name))
-    _ = shutil.make_archive(output_archive_path, "zip", ext_path)
-    return Path(output_archive_path + ".zip")

--- a/lib_bpybuild_ext/__init__.py
+++ b/lib_bpybuild_ext/__init__.py
@@ -122,10 +122,11 @@ def get_manifest_data(manifest_path: Path) -> manifest.ManifestData:
                     f"{key} contains value that uses blacklisted characters"
                 )
         if hasattr(manifest_data, key):
-            if not isinstance(val, getattr(manifest_data, key)):  # type: ignore[misc]
-                # TODO: Implement a way to tell the user what type it should be
-                raise TypeError(
-                    f"{key} is not the correct type! See the Blender docs for more info"
-                )
+            # TODO: Enable when we move to Python 3.9
+            # if not isinstance(val, manifest.ManifestData.__annotations__[key]):  # type: ignore[misc]
+            #    # TODO: Implement a way to tell the user what type it should be
+            #    raise TypeError(
+            #        f"{key} is not the correct type! See the Blender docs for more info"
+            #    )
             setattr(manifest_data, key, val)  # type: ignore[misc]
     return manifest_data

--- a/lib_bpybuild_ext/manifest.py
+++ b/lib_bpybuild_ext/manifest.py
@@ -1,0 +1,136 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, Mahid Sheikh
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Disclaimer: This is not a product from VLK Architects or VLK Experience Design,
+# nor is this endorsed by VLK Architects or VLK Experience Design
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from typing_extensions import NotRequired, TypedDict
+
+# Note: We only support the addon subset of manifest data, and
+# only 1.0.0 of the manifest schema
+ManifestSchemaLiteral = Literal["1.0.0"]
+ManifestTypeLiteral = Literal["add-on"]
+ManifestPermissionsLiteral = Literal[
+    "files", "network", "clipboard", "camera", "microphone"
+]
+ManifestTagsLiteral = Literal[
+    "3D View",
+    "Add Curve",
+    "Add Mesh",
+    "Animation",
+    "Bake",
+    "Camera",
+    "Compositing",
+    "Development",
+    "Game Engine",
+    "Geometry Nodes",
+    "Grease Pencil",
+    "Import-Export",
+    "Lighting",
+    "Material",
+    "Modeling",
+    "Mesh",
+    "Node",
+    "Object",
+    "Paint",
+    "Pipeline",
+    "Physics",
+    "Render",
+    "Rigging",
+    "Scene",
+    "Sculpt",
+    "Sequencer",
+    "System",
+    "Text Editor",
+    "Tracking",
+    "User Interface",
+    "UV",
+]
+
+ManifestPlatformLiteral = Literal[
+    "windows-amd64", "macos-arm64", "linux-x86_64", "windows-arm64", "macos-x86_64"
+]
+
+
+class ManifestBuildTypedDict(TypedDict):
+    paths_exclude_pattern: NotRequired[list[str]]
+
+
+class ManifestTypedDict(TypedDict):
+    schema_version: ManifestSchemaLiteral
+    id: str
+    version: str
+    name: str
+    tagline: str
+    maintainer: str
+    type: ManifestTypeLiteral
+
+    permissions: NotRequired[list[ManifestPermissionsLiteral]]
+    website: NotRequired[str]
+    tags: NotRequired[list[ManifestTagsLiteral]]
+
+    blender_version_min: str
+    blender_version_max: NotRequired[str]
+
+    license: list[str]
+    copyright: NotRequired[list[str]]
+
+    platforms: NotRequired[list[ManifestPlatformLiteral]]
+    wheels: NotRequired[list[str]]
+    build: NotRequired[ManifestBuildTypedDict]
+
+
+@dataclass
+class ManifestData:
+    schema_version: ManifestSchemaLiteral = "1.0.0"
+    id: str = "my_example_extension"
+    version: str = "1.0.0"
+    name: str = "Test Extension"
+    tagline: str = "This is another extension"
+    maintainer: str = "Developer name <email@address.com>"
+    type: ManifestTypeLiteral = "add-on"
+
+    permissions: Optional[list[ManifestPermissionsLiteral]] = None
+    website: Optional[str] = None
+    tags: Optional[list[ManifestTagsLiteral]] = None
+
+    blender_version_min: str = "4.2.0"
+    blender_version_max: Optional[str] = None
+
+    license: list[str] = ["SPDX:GPL-2.0-or-later"]
+    copyright: Optional[list[str]] = None
+
+    platforms: Optional[list[ManifestPlatformLiteral]] = None
+    wheels: Optional[list[str]] = None
+    build: Optional[ManifestBuildTypedDict] = None

--- a/lib_bpybuild_ext/manifest.py
+++ b/lib_bpybuild_ext/manifest.py
@@ -39,11 +39,10 @@ from typing_extensions import NotRequired, TypedDict
 
 # Note: We only support the addon subset of manifest data, and
 # only 1.0.0 of the manifest schema
+#
+# TODO: Implement theme support
 ManifestSchemaLiteral = Literal["1.0.0"]
 ManifestTypeLiteral = Literal["add-on"]
-ManifestPermissionsLiteral = Literal[
-    "files", "network", "clipboard", "camera", "microphone"
-]
 ManifestTagsLiteral = Literal[
     "3D View",
     "Add Curve",
@@ -82,9 +81,21 @@ ManifestPlatformLiteral = Literal[
     "windows-amd64", "macos-arm64", "linux-x86_64", "windows-arm64", "macos-x86_64"
 ]
 
+ManifestPermissionsLiteral = Literal[
+    "files", "network", "clipboard", "camera", "microphone"
+]
+
 
 class ManifestBuildTypedDict(TypedDict):
     paths_exclude_pattern: NotRequired[list[str]]
+
+
+class ManifestPermissionsTypedDict(TypedDict):
+    files: NotRequired[str]
+    network: NotRequired[str]
+    clipboard: NotRequired[str]
+    camera: NotRequired[str]
+    microphone: NotRequired[str]
 
 
 class ManifestTypedDict(TypedDict):
@@ -96,7 +107,7 @@ class ManifestTypedDict(TypedDict):
     maintainer: str
     type: ManifestTypeLiteral
 
-    permissions: NotRequired[list[ManifestPermissionsLiteral]]
+    permissions: NotRequired[ManifestPermissionsTypedDict]
     website: NotRequired[str]
     tags: NotRequired[list[ManifestTagsLiteral]]
 
@@ -121,7 +132,7 @@ class ManifestData:
     maintainer: str = "Developer name <email@address.com>"
     type: ManifestTypeLiteral = "add-on"
 
-    permissions: Optional[list[ManifestPermissionsLiteral]] = None
+    permissions: Optional[ManifestPermissionsTypedDict] = None
     website: Optional[str] = None
     tags: Optional[list[ManifestTagsLiteral]] = None
 

--- a/lib_bpybuild_ext/manifest.py
+++ b/lib_bpybuild_ext/manifest.py
@@ -32,7 +32,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Optional
 
 from typing_extensions import NotRequired, TypedDict
@@ -139,7 +139,7 @@ class ManifestData:
     blender_version_min: str = "4.2.0"
     blender_version_max: Optional[str] = None
 
-    license: list[str] = ["SPDX:GPL-2.0-or-later"]
+    license: list[str] = field(default_factory=lambda: ["SPDX:GPL-2.0-or-later"])
     copyright: Optional[list[str]] = None
 
     platforms: Optional[list[ManifestPlatformLiteral]] = None

--- a/lib_bpybuild_ext/verify.py
+++ b/lib_bpybuild_ext/verify.py
@@ -50,10 +50,6 @@ RE_MANIFEST_SEMVER = re.compile(
     r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 )
 
-RE_MANIFEST_COPYRIGHT = re.compile(
-    r"([\d]+)\s[a-zA-Z\s].*$" r"([\d]+-[\d]+)\s[a-zA-Z\s].*$"
-)
-
 CHARACTER_LIMIT = 64
 
 
@@ -145,10 +141,13 @@ def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -
 
     if manifest_data.copyright is not None:
         for copyright in manifest_data.copyright:
-            if not RE_MANIFEST_COPYRIGHT.match(copyright):
+            year, _, name = copyright.partition(" ")
+            if not all(x.isdigit() for x in year.partition("-")[0::2]):
                 raise TypeError(
                     f'{copyright} is not in the proper format; supported format: ("YEAR First Last", "YEAR-YEAR First Last") '
                 )
+            if not name.strip():
+                raise TypeError("Name for copyright must not be empty")
 
     if manifest_data.permissions is not None:
         for p in manifest_data.permissions:

--- a/lib_bpybuild_ext/verify.py
+++ b/lib_bpybuild_ext/verify.py
@@ -80,9 +80,9 @@ def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -
 
     # If it's not in our list of compatible schema versions, we
     # certainly can't parse or deal with it
-    if manifest_data.schema_version not in cast(
-        tuple[str], get_args(manifest.ManifestSchemaLiteral)
-    ):
+
+    # Python 3.8 typing woes requires us to ignore these get_args calls
+    if manifest_data.schema_version not in get_args(manifest.ManifestSchemaLiteral):  # type: ignore[misc]
         raise TypeError("Schema version incompatible with LibBpyBuildExt")
 
     if not RE_MANIFEST_SEMVER.match(manifest_data.version):
@@ -129,16 +129,16 @@ def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -
         if license[:4] != "SPDX":
             raise TypeError(f'License {license} missing "SPDX:" prefix')
 
-    if manifest_data.type not in cast(
-        tuple[str], get_args(manifest.ManifestTypeLiteral)
-    ):
+    # Python 3.8 typing woes requires us to ignore these get_args calls
+    if manifest_data.type not in get_args(manifest.ManifestTypeLiteral):  # type: ignore[misc]
         raise TypeError(
-            f"Invalid extension type; supported types: {cast(tuple[str], get_args(manifest.ManifestTypeLiteral))}"
+            f"Invalid extension type; supported types: {get_args(manifest.ManifestTypeLiteral)}"  # type: ignore[misc]
         )
 
     if manifest_data.tags is not None:
         for t in manifest_data.tags:
-            if t not in cast(tuple[str], get_args(manifest.ManifestTagsLiteral)):
+            # Python 3.8 typing woes requires us to ignore these get_args calls
+            if t not in get_args(manifest.ManifestTagsLiteral):  # type: ignore[misc]
                 raise TypeError(
                     f"{t} is not a compatible tag; supported tags: {cast(tuple[str], get_args(manifest.ManifestTagsLiteral))}"
                 )

--- a/lib_bpybuild_ext/verify.py
+++ b/lib_bpybuild_ext/verify.py
@@ -1,0 +1,100 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, Mahid Sheikh
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Disclaimer: This is not a product from VLK Architects or VLK Experience Design,
+# nor is this endorsed by VLK Architects or VLK Experience Design
+
+from __future__ import annotations
+
+from typing import cast, get_args
+
+from . import manifest
+
+COMPATIBLE_SCHEMA_VERSIONS = ["1.0.0"]
+
+# TODO: Implement theme support
+EXTENSION_TYPES = ["add-on"]
+
+
+def verify_manifest(manifest_data: manifest.ManifestData) -> None:
+    """Verify a Blender Extension manifest based on the
+    criteria given by the Blender manual.
+
+    We are aware that there is some extra things that the
+    Blender Extension builder checks for upstream, but
+    the way we see it, it's up to the Blender Foundation
+    to properly document everything. If it isn't important
+    enough for them to document it, then it isn't important
+    enough for us to implement it.
+
+    We don't check for missing values because we already assign a
+    set of default values anyway.
+
+    :param manifest: The manifest data parsed from blender_manifest.toml
+    :type manifest: ManifestData
+
+    :raises TypeError: If a manifest value does not pass manifest verification
+    """
+
+    if manifest_data.schema_version not in COMPATIBLE_SCHEMA_VERSIONS:
+        raise TypeError("Schema version incompatible with LibBpyBuildExt")
+
+    # Although the Blender Extension builder allows ), }, and ] at the
+    # the end of taglines, we will simply not support it as this is not
+    # not mention in the documentation. If it isn't important enough to be
+    # mentioned in the documentation, it isn't needed in LibBpyBuildExt
+    if not manifest_data.tagline[-1:].isalnum():
+        raise TypeError("Tagline must not end in punctuation")
+
+    for license in manifest_data.license:
+        if license[:4] != "SPDX":
+            raise TypeError(f'License {license} missing "SPDX:" prefix')
+
+    if manifest_data.type not in EXTENSION_TYPES:
+        raise TypeError(f"Invalid extension type; supported types: {EXTENSION_TYPES}")
+
+    if manifest_data.tags is not None:
+        for t in manifest_data.tags:
+            if t not in cast(tuple[str], get_args(manifest.ManifestTagsLiteral)):
+                raise TypeError(
+                    f"{t} is not a compatible tag; supported tags: {cast(tuple[str], get_args(manifest.ManifestTagsLiteral))}"
+                )
+
+    if manifest_data.permissions is not None:
+        for p in manifest_data.permissions:
+            if p not in cast(tuple[str], get_args(manifest.ManifestPermissionsLiteral)):
+                raise TypeError(
+                    f"{p} is not a valid permission; supported permissions {manifest.ManifestPermissionsLiteral}"
+                )
+            if not manifest_data.permissions[
+                cast(manifest.ManifestPermissionsLiteral, p)
+            ][-1:].isalnum():
+                raise TypeError(
+                    f"Explaination for permission {p} must not end in punctuation"
+                )

--- a/lib_bpybuild_ext/verify.py
+++ b/lib_bpybuild_ext/verify.py
@@ -54,6 +54,8 @@ RE_MANIFEST_COPYRIGHT = re.compile(
     r"([\d]+)\s[a-zA-Z\s].*$" r"([\d]+-[\d]+)\s[a-zA-Z\s].*$"
 )
 
+CHARACTER_LIMIT = 64
+
 
 def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -> None:
     """Verify a Blender Extension manifest based on the
@@ -109,6 +111,9 @@ def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -
     if not manifest_data.tagline[-1:].isalnum():
         raise TypeError("Tagline must not end in punctuation")
 
+    if len(manifest_data.tagline) == CHARACTER_LIMIT:
+        raise TypeError("Tagline can not be greater then 64 characters!")
+
     # TODO: Check against the SPDX database to validate
     # that the passed license is indeed a SPDX license
     for license in manifest_data.license:
@@ -161,6 +166,18 @@ def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -
             ][-1:].isalnum():
                 raise TypeError(
                     f"Explaination for permission {p} must not end in punctuation"
+                )
+
+            if (
+                len(
+                    manifest_data.permissions[
+                        cast(manifest.ManifestPermissionsLiteral, p)
+                    ]
+                )
+                == CHARACTER_LIMIT
+            ):
+                raise TypeError(
+                    f"Explaination for permission {p} may not be greater then 64 characters"
                 )
 
     if manifest_data.wheels is not None:

--- a/lib_bpybuild_ext/verify.py
+++ b/lib_bpybuild_ext/verify.py
@@ -100,6 +100,19 @@ def verify_manifest(manifest_data: manifest.ManifestData, manifest_path: Path) -
             f"{manifest_data.blender_version_min} is not in the correct format that Blender versions follow"
         )
 
+    if manifest_data.blender_version_max is not None:
+        try:
+            min_version = Version(manifest_data.blender_version_min)
+            max_version = Version(manifest_data.blender_version_max)
+            if min_version == max_version:
+                raise TypeError(
+                    "Cannot use the same version for both blender_version_min and blender_version_max"
+                )
+        except InvalidVersion:
+            raise TypeError(
+                f"{manifest_data.blender_version_max} is not in the correct format that Blender versions follow"
+            )
+
     # Although the Blender Extension builder allows ), }, and ] at the
     # the end of taglines, we will simply not support it as this is not
     # not mention in the documentation. If it isn't important enough to be

--- a/poetry.lock
+++ b/poetry.lock
@@ -352,4 +352,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "5235c5d38dc9601654f7df8db674e6d491447344824a0761f77ff3ee6457acd8"
+content-hash = "c23d659962b86f4abf5e96dc7c024b72e62234b5ef1a73259f7de28302bcb626"

--- a/poetry.lock
+++ b/poetry.lock
@@ -53,22 +53,22 @@ test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit",
 
 [[package]]
 name = "importlib-metadata"
-version = "7.1.0"
+version = "8.0.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
-    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
+    {file = "importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f"},
+    {file = "importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"},
 ]
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "markdown-it-py"
@@ -107,38 +107,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.10.0"
+version = "1.10.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2"},
-    {file = "mypy-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99"},
-    {file = "mypy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2"},
-    {file = "mypy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9"},
-    {file = "mypy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051"},
-    {file = "mypy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1"},
-    {file = "mypy-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee"},
-    {file = "mypy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de"},
-    {file = "mypy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7"},
-    {file = "mypy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53"},
-    {file = "mypy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b"},
-    {file = "mypy-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30"},
-    {file = "mypy-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e"},
-    {file = "mypy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5"},
-    {file = "mypy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda"},
-    {file = "mypy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9fd50226364cd2737351c79807775136b0abe084433b55b2e29181a4c3c878c0"},
-    {file = "mypy-1.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f90cff89eea89273727d8783fef5d4a934be2fdca11b47def50cf5d311aff727"},
-    {file = "mypy-1.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcfc70599efde5c67862a07a1aaf50e55bce629ace26bb19dc17cece5dd31ca4"},
-    {file = "mypy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:075cbf81f3e134eadaf247de187bd604748171d6b79736fa9b6c9685b4083061"},
-    {file = "mypy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:3f298531bca95ff615b6e9f2fc0333aae27fa48052903a0ac90215021cdcfa4f"},
-    {file = "mypy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa7ef5244615a2523b56c034becde4e9e3f9b034854c93639adb667ec9ec2976"},
-    {file = "mypy-1.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3236a4c8f535a0631f85f5fcdffba71c7feeef76a6002fcba7c1a8e57c8be1ec"},
-    {file = "mypy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2b5cdbb5dd35aa08ea9114436e0d79aceb2f38e32c21684dcf8e24e1e92821"},
-    {file = "mypy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92f93b21c0fe73dc00abf91022234c79d793318b8a96faac147cd579c1671746"},
-    {file = "mypy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:28d0e038361b45f099cc086d9dd99c15ff14d0188f44ac883010e172ce86c38a"},
-    {file = "mypy-1.10.0-py3-none-any.whl", hash = "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee"},
-    {file = "mypy-1.10.0.tar.gz", hash = "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7"},
+    {file = "mypy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a"},
+    {file = "mypy-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9"},
+    {file = "mypy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84"},
+    {file = "mypy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f"},
+    {file = "mypy-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b"},
+    {file = "mypy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3"},
+    {file = "mypy-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e"},
+    {file = "mypy-1.10.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04"},
+    {file = "mypy-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade"},
+    {file = "mypy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37"},
+    {file = "mypy-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7"},
+    {file = "mypy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf"},
+    {file = "mypy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531"},
+    {file = "mypy-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3"},
+    {file = "mypy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f"},
+    {file = "mypy-1.10.1-py3-none-any.whl", hash = "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a"},
+    {file = "mypy-1.10.1.tar.gz", hash = "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0"},
 ]
 
 [package.dependencies]
@@ -161,6 +161,17 @@ python-versions = ">=3.5"
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
+name = "packaging"
+version = "24.1"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
@@ -325,31 +336,31 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.1"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
-    {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
 name = "zipp"
-version = "3.19.1"
+version = "3.19.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.19.1-py3-none-any.whl", hash = "sha256:2828e64edb5386ea6a52e7ba7cdb17bb30a73a858f5eb6eb93d8d36f5ea26091"},
-    {file = "zipp-3.19.1.tar.gz", hash = "sha256:35427f6d5594f4acf82d25541438348c26736fa9b3afa2754bcd63cdb99d8e8f"},
+    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
+    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
 ]
 
 [package.extras]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "c23d659962b86f4abf5e96dc7c024b72e62234b5ef1a73259f7de28302bcb626"
+content-hash = "ac1833f5a27dafc68b7b988fe7fbc5d091ce3e09bd2d72699f6d0bbc457d4340"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [tool.poetry]
 name = "bpy-addon-build"
-version = "0.4.1"
+version = "0.4.2"
 description = "A build system to make building and testing Blender addons 10 times easier"
-authors = ["StandingPad"]
+authors = ["Mahid Sheikh <mahid@standingpad.org>"]
 license = "BSD-3-Clause"
 homepage = "https://github.com/StandingPadAnimations/bpy-build"
+
+packages = [
+    { include = "bpy_addon_build" },
+    { include = "lib_bpybuild_ext" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
@@ -13,6 +18,7 @@ pyyaml = "^6.0.1"
 rich = "^13.7.0"
 typeguard = "^4.1.5"
 typing-extensions = "^4.11.0"
+tomli = "^2.0.1"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ rich = "^13.7.0"
 typeguard = "^4.1.5"
 typing-extensions = "^4.11.0"
 tomli = "^2.0.1"
+packaging = "^24.1"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
-attrs==23.1.0
-pyyaml==6.0.1
-cattrs==23.2.3
-rich==13.7.0
-typeguard==4.1.5
-mypy==1.4.1
-types-pyyaml==6.0.12.1
-ruff==0.3.4
-GitPython==3.1.43
+attrs==23.2.0 ; python_version >= "3.8"
+importlib-metadata==8.0.0 ; python_version < "3.10" and python_version >= "3.8"
+markdown-it-py==3.0.0 ; python_version >= "3.8"
+mdurl==0.1.2 ; python_version >= "3.8"
+packaging==24.1 ; python_version >= "3.8"
+pygments==2.18.0 ; python_version >= "3.8"
+pyyaml==6.0.1 ; python_version >= "3.8"
+rich==13.7.1 ; python_version >= "3.8"
+tomli==2.0.1 ; python_version >= "3.8"
+typeguard==4.3.0 ; python_version >= "3.8"
+typing-extensions==4.12.2 ; python_version >= "3.8"
+zipp==3.19.2 ; python_version < "3.10" and python_version >= "3.8"


### PR DESCRIPTION
BpyBuild 0.4.2 wasn't planned, but with the arrival of extensions, we've decided that it's necessary to have basic extension support in BpyBuild.

This PR implements the following:
- `lib_bpybuild_ext`, an independent, BSD licensed implementation of the Blender Extension builder
	- Based solely on the documentation, so not 100% compatible with upstream. That said, it should be compatible enough
- Extension support; Extension support is opt-in at the moment, and will become the default in BpyBuild 0.5 (with an opt-out)
	- [x] Building and installation of extensions
	- [ ] Building extensions with legacy addons. This is not a blocking issue, and we can proceed with BpyBuild 0.4.2 without it, but would be nice to have it in 0.4.2